### PR TITLE
fix: edit link for split repos

### DIFF
--- a/scripts/PrepareMdToJson.re
+++ b/scripts/PrepareMdToJson.re
@@ -8,6 +8,7 @@ Lowlight.(lowlight->registerLanguage("reason", reason));
 [@bs.module] external mdToJson: string => 'a = "@phenomic/markdown-as-json";
 
 Js.log("Docs pages...");
+
 let sourcePath = Path.join([|root, "docs"|]);
 let outputPath = Path.join([|root, "build", "docs-pages"|]);
 Path.join([|sourcePath, "**/*.md"|])
@@ -24,7 +25,12 @@ Path.join([|sourcePath, "**/*.md"|])
           let mdJson = mdToJson(file.content);
           let content =
             {
-              "filename": file.name |> Js.String.replace(root, ""),
+              "filename":
+                file.name
+                |> Js.String.replace(
+                     root,
+                     "reason-react-native.github.io/blob/src/",
+                   ),
               "id": mdJson##id,
               "title": mdJson##title,
               "body": mdJson##body,
@@ -84,6 +90,10 @@ Path.join([|sourcePath, "**/*.md"|])
                 |> Js.String.replace(
                      Node.Path.resolve(root, "..") ++ "/",
                      "",
+                   )
+                |> Js.String.replace(
+                     "reason-react-native",
+                     "reason-react-native/blob/master",
                    ),
               "id": mdJson##id,
               "title": mdJson##title,
@@ -150,7 +160,12 @@ Path.join([|sourcePath, "**/*.md"|])
           let mdJson = mdToJson(file.content);
           let content =
             {
-              "filename": file.name |> Js.String.replace(root, ""),
+              "filename":
+                file.name
+                |> Js.String.replace(
+                     root,
+                     "reason-react-native.github.io/blob/src/",
+                   ),
               "id": mdJson##id,
               "title": mdJson##title,
               "author": mdJson##author,

--- a/src/components/PageContent.re
+++ b/src/components/PageContent.re
@@ -90,8 +90,7 @@ let make = (~pageData) => {
       None;
     };
   let editHref =
-    "https://github.com/reason-react-native/reason-react-native.github.io/blob/src/"
-    ++ pageData.filename;
+    "https://github.com/reason-react-native/" ++ pageData.filename;
   <SpacedView style=styles##container vertical=SpacedView.L>
     <main>
       <header>


### PR DESCRIPTION
<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/.github/blob/master/CONTRIBUTING.md

-->

Closes #6 

<!--
Add any information that might be useful
-->

I've edited the filename so that when users click on the Edit button,
files from this repo will link to this repo, and files from `reason-react-native` repo will link to `reason-react-native` repo