### PR TITLE
Update to use the actual script names in templates

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -134,13 +134,13 @@ are unfamiliar with _Android Studio_, you might be interested by
 **In another terminal:**
 
 ```console
-yarn start:ios
+yarn ios
 ```
 
 or
 
 ```console
-yarn start:android
+yarn android
 ```
 
 This commands should open up a virtual device & start React Native


### PR DESCRIPTION
otherwise this can be confusing, because the "start:ios" and "start:android" do not exist in the package.json scripts in the template. note: just running "yarn ios" or "yarn android" will kick off the metro bundler anyway if it's not already running :)

This is only a documentation edit.

<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/.github/blob/master/CONTRIBUTING.md

-->

Closes #<number-of-the-issue>

<!--
Add any information that might be useful
-->
