### PR TITLE
change full template name to short template name

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -33,7 +33,7 @@ When you have correctly
 installed, you can run the following command:
 
 ```console
-npx react-native init MyApp --template reason-react-native-template
+npx react-native init MyApp --template reason
 cd MyApp
 ```
 


### PR DESCRIPTION
npx react-native init MyApp --template reason

yarn will fill to full template name

<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/.github/blob/master/CONTRIBUTING.md

-->

Closes #<number-of-the-issue>

<!--
Add any information that might be useful
-->
