### PR TITLE
docs: renew url for react-native docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: Getting Started
 ---
 
 _Reason React Native_ is a safe & simple way to build
-[React Native](http://facebook.github.io/react-native/) apps, in
+[React Native](https://reactnative.dev/) apps, in
 [Reason](http://reasonml.github.io/), using
 [ReasonReact](https://reasonml.github.io/reason-react/).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -19,7 +19,7 @@ All options will basically help you to have :
 
 Below we assume you are already familiar with React Native. If you are new to
 React Native, please have a quick look to
-[React Native Getting Started documentation](https://facebook.github.io/react-native/docs/getting-started.html)
+[React Native Getting Started documentation](https://reactnative.dev/docs/getting-started.html)
 in order to get the minimal requirements.
 
 ## Create a new project with _Reason React Native_
@@ -29,7 +29,7 @@ choosing this option you will get an hello world project that will already have
 all the requirements included.
 
 When you have correctly
-[`react-native-cli`](http://facebook.github.io/react-native/docs/getting-started#the-react-native-cli)
+[`react-native-cli`](https://reactnative.dev/docs/getting-started#the-react-native-cli)
 installed, you can run the following command:
 
 ```console

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,7 +149,7 @@ the compiled Reason code to the React Native client.
 
 Now you can start coding by editing files in `src/`!
 
-[Read more about starting the project in your environment of choice](http://facebook.github.io/react-native/docs/getting-started).
+[Read more about starting the project in your environment of choice](https://reactnative.dev/docs/getting-started).
 
 **Note: as soon as you have the app installed in a simulator/emulator, you can
 just run**

--- a/src/components/PageContent.re
+++ b/src/components/PageContent.re
@@ -82,7 +82,7 @@ let make = (~pageData) => {
                || pageData.id
                |> Js.String.startsWith("components/")) {
       Some(
-        "http://facebook.github.io/react-native/docs/"
+        "https://reactnative.dev/docs/"
         ++ pageData.title->Js.String.toLocaleLowerCase
         ++ "/",
       );


### PR DESCRIPTION
<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/.github/blob/master/CONTRIBUTING.md

-->

The documentation of react-native has been changed from `https://facebook.github.io/react-native` to `https://reactnative.dev`

Renew the url in the docs to match the new url.
<!--
Add any information that might be useful
-->
