### PR TITLE
chore: fix warning by using String.uppercase_ascii

### DIFF
--- a/src/components/SidebarBlog.re
+++ b/src/components/SidebarBlog.re
@@ -52,7 +52,7 @@ let make = (~blogIndex) => {
   <SpacedView>
     <SpacedView vertical=SpacedView.M horizontal=SpacedView.None>
       <Text style=styles##title>
-        {"Recent posts"->String.uppercase->React.string}
+        {"Recent posts"->String.uppercase_ascii->React.string}
       </Text>
     </SpacedView>
     {{blogIndex->Array.map(indexEntry =>

--- a/src/components/SidebarDocs.re
+++ b/src/components/SidebarDocs.re
@@ -109,7 +109,7 @@ let make = (~docsIndex, ~currentLocation) => {
              )}>
              <SpacedView vertical=M horizontal=None>
                <Text style=styles##title>
-                 {section.title->String.uppercase->React.string}
+                 {section.title->String.uppercase_ascii->React.string}
                </Text>
              </SpacedView>
            </div>


### PR DESCRIPTION
<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/.github/blob/master/CONTRIBUTING.md

-->

Building the website gives deprecated warning for using `String.uppercase`
warning is removed by using `String.uppercase_ascii` instead.


<!--
Add any information that might be useful
-->
